### PR TITLE
Enable Swagger UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Spring Boot microservice to collect historical stock and bond data from Yahoo Fi
 mvn spring-boot:run
 ```
 
-Swagger UI available at [http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html)
+Swagger UI available at [http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html)

--- a/pom.xml
+++ b/pom.xml
@@ -54,12 +54,18 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
-		<!-- https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-annotations -->
-		<dependency>
-			<groupId>io.swagger.core.v3</groupId>
-			<artifactId>swagger-annotations</artifactId>
-			<version>2.2.31</version>
-		</dependency>
+                <!-- https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-annotations -->
+                <dependency>
+                        <groupId>io.swagger.core.v3</groupId>
+                        <artifactId>swagger-annotations</artifactId>
+                        <version>2.2.31</version>
+                </dependency>
+                <!-- Swagger UI and OpenAPI integration -->
+                <dependency>
+                        <groupId>org.springdoc</groupId>
+                        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+                        <version>2.5.0</version>
+                </dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
- add springdoc-openapi UI dependency to enable Swagger interface
- update Swagger UI link in README

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857c3d68960832a904c15eebc76edf1